### PR TITLE
Add privacy policy page with styling

### DIFF
--- a/_sass/_privacy.scss
+++ b/_sass/_privacy.scss
@@ -1,0 +1,160 @@
+.privacy-wrap {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 72px 24px 96px;
+
+  .label {
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 12px;
+  }
+
+  h1 {
+    font-family: var(--sans);
+    font-size: clamp(32px, 4vw, 48px);
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+    margin-bottom: 10px;
+  }
+
+  .privacy-meta {
+    font-size: 13px;
+    color: var(--muted);
+    margin-bottom: 52px;
+  }
+}
+
+.privacy-toc {
+  background: var(--off);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 28px 32px;
+  margin-bottom: 48px;
+
+  h2 {
+    font-family: var(--sans);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 16px;
+  }
+
+  ol {
+    list-style: none;
+    counter-reset: toc;
+    padding: 0;
+    margin: 0;
+  }
+
+  li {
+    counter-increment: toc;
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 6px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 14px;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &::before {
+      content: counter(toc, decimal-leading-zero);
+      font-size: 11px;
+      color: var(--muted);
+      min-width: 20px;
+      flex-shrink: 0;
+    }
+  }
+
+  a {
+    color: var(--body);
+    text-decoration: none;
+    transition: color 0.2s;
+
+    &:hover {
+      color: var(--accent);
+    }
+  }
+
+  @media (max-width: 480px) {
+    padding: 20px 20px;
+  }
+}
+
+.privacy-section {
+  padding: 36px 0;
+  border-top: 1px solid var(--border);
+
+  .section-num {
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 6px;
+  }
+
+  h2 {
+    font-family: var(--sans);
+    font-size: 22px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--body);
+    margin-bottom: 18px;
+  }
+
+  p {
+    font-size: 16px;
+    line-height: 1.8;
+    color: #2a2a28;
+    margin-bottom: 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    strong {
+      font-weight: 500;
+      color: var(--body);
+    }
+  }
+
+  ul, ol {
+    padding-left: 22px;
+    margin-bottom: 16px;
+
+    li {
+      font-size: 16px;
+      line-height: 1.8;
+      color: #2a2a28;
+      margin-bottom: 6px;
+
+      strong {
+        font-weight: 500;
+        color: var(--body);
+      }
+    }
+  }
+}
+
+.privacy-callout {
+  background: var(--off);
+  border-left: 3px solid var(--accent);
+  padding: 16px 20px;
+  margin: 20px 0;
+  border-radius: 0 6px 6px 0;
+  font-size: 15px;
+  line-height: 1.7;
+  color: #2a2a28;
+
+  strong {
+    font-weight: 500;
+    color: var(--body);
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,3 +11,4 @@
 @import "blog";
 @import "post";
 @import "contact";
+@import "privacy";

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -1,0 +1,145 @@
+---
+layout: default
+title: Privacy Policy
+description: Privacy policy for this website — how we collect, use, and protect your information.
+permalink: /privacy-policy/
+---
+
+<div class="privacy-wrap">
+  <p class="label">Legal</p>
+  <h1>Privacy Policy</h1>
+  <p class="privacy-meta">Last updated: <span id="privacy-date"></span></p>
+
+  <div class="privacy-toc">
+    <h2>Contents</h2>
+    <ol>
+      <li><a href="#intro">Introduction</a></li>
+      <li><a href="#data-collected">Information We Collect</a></li>
+      <li><a href="#how-used">How We Use Your Information</a></li>
+      <li><a href="#cookies">Cookies &amp; Analytics</a></li>
+      <li><a href="#sharing">Data Sharing &amp; Disclosure</a></li>
+      <li><a href="#retention">Data Retention</a></li>
+      <li><a href="#rights">Your Rights</a></li>
+      <li><a href="#security">Security</a></li>
+      <li><a href="#changes">Changes to This Policy</a></li>
+      <li><a href="#contact">Contact Us</a></li>
+    </ol>
+  </div>
+
+  <section class="privacy-section" id="intro">
+    <div class="section-num">01</div>
+    <h2>Introduction</h2>
+    <p>Welcome. This Privacy Policy explains how this website ("we," "us," or "our") collects, uses, and protects information about you when you visit or interact with our site.</p>
+    <p>By using this website, you agree to the practices described in this policy. If you do not agree, please discontinue use of the site.</p>
+    <div class="privacy-callout">
+      <strong>In plain terms:</strong> We only collect what we need — contact form submissions and anonymized analytics data. We don't sell your information.
+    </div>
+  </section>
+
+  <section class="privacy-section" id="data-collected">
+    <div class="section-num">02</div>
+    <h2>Information We Collect</h2>
+    <p>We collect information in two ways:</p>
+    <p><strong>Information you provide directly</strong> — When you fill out a contact form on our website, we may collect:</p>
+    <ul>
+      <li>Your name</li>
+      <li>Your email address</li>
+      <li>Any message or other details you choose to include</li>
+    </ul>
+    <p><strong>Information collected automatically</strong> — When you visit our site, certain technical data is collected automatically through cookies and similar technologies, including:</p>
+    <ul>
+      <li>Browser type and version</li>
+      <li>Pages visited and time spent on each page</li>
+      <li>Referring URL (how you arrived at our site)</li>
+      <li>General geographic location (country or region)</li>
+      <li>Device type and operating system</li>
+    </ul>
+    <p>We do not collect sensitive personal information such as financial data, government identification numbers, or health information.</p>
+  </section>
+
+  <section class="privacy-section" id="how-used">
+    <div class="section-num">03</div>
+    <h2>How We Use Your Information</h2>
+    <p>We use the information we collect for the following purposes:</p>
+    <ul>
+      <li><strong>To respond to your inquiries</strong> — Contact form submissions are used solely to reply to your message.</li>
+      <li><strong>To improve our website</strong> — Analytics data helps us understand which content is useful and how visitors navigate the site.</li>
+      <li><strong>To maintain site functionality</strong> — Certain cookies are necessary for the website to operate correctly.</li>
+    </ul>
+    <p>We do not use your personal information for automated decision-making or profiling.</p>
+  </section>
+
+  <section class="privacy-section" id="cookies">
+    <div class="section-num">04</div>
+    <h2>Cookies &amp; Analytics</h2>
+    <p>This website uses cookies — small text files placed on your device — to enable analytics. Specifically:</p>
+    <ul>
+      <li><strong>Analytics cookies</strong> track aggregate, anonymized visitor behaviour to help us understand site performance. This data does not identify you personally.</li>
+      <li><strong>Functional cookies</strong> may be used to remember preferences or maintain session state.</li>
+    </ul>
+    <p>We do not use advertising or tracking cookies that follow you across other websites.</p>
+    <div class="privacy-callout">
+      <strong>Your choice:</strong> Most browsers allow you to refuse or delete cookies via their settings. Disabling cookies may affect some functionality, but will not prevent you from using the site.
+    </div>
+    <p>If we use a third-party analytics tool (such as Google Analytics), that provider may also set cookies subject to their own privacy policy. We encourage you to review their terms separately.</p>
+  </section>
+
+  <section class="privacy-section" id="sharing">
+    <div class="section-num">05</div>
+    <h2>Data Sharing &amp; Disclosure</h2>
+    <p>We do not sell, rent, or trade your personal information to any third party.</p>
+    <p>We may share your information only in the following limited circumstances:</p>
+    <ul>
+      <li><strong>Service providers</strong> — Trusted third parties who assist with site hosting or analytics, bound by confidentiality obligations.</li>
+      <li><strong>Legal requirements</strong> — If required by law, court order, or to protect the rights and safety of ourselves or others.</li>
+      <li><strong>Business transfers</strong> — In the unlikely event of a merger or acquisition, your information may be transferred as part of that transaction.</li>
+    </ul>
+  </section>
+
+  <section class="privacy-section" id="retention">
+    <div class="section-num">06</div>
+    <h2>Data Retention</h2>
+    <p>We retain contact form submissions only as long as necessary to respond to your inquiry and for a reasonable period thereafter for record-keeping purposes.</p>
+    <p>Analytics data is retained in aggregated, anonymized form and does not personally identify you.</p>
+    <p>You may request deletion of your personal data at any time by contacting us (see Section 10).</p>
+  </section>
+
+  <section class="privacy-section" id="rights">
+    <div class="section-num">07</div>
+    <h2>Your Rights</h2>
+    <p>Depending on your location, you may have certain rights regarding your personal data, including the right to:</p>
+    <ul>
+      <li><strong>Access</strong> — Request a copy of the personal data we hold about you.</li>
+      <li><strong>Correction</strong> — Request that inaccurate or incomplete data be corrected.</li>
+      <li><strong>Deletion</strong> — Request that we delete your personal data, subject to legal obligations.</li>
+      <li><strong>Objection</strong> — Object to certain uses of your data.</li>
+      <li><strong>Portability</strong> — Request your data in a structured, commonly used format.</li>
+    </ul>
+    <p>To exercise any of these rights, please reach out via the contact information in Section 10. We will respond within a reasonable timeframe.</p>
+  </section>
+
+  <section class="privacy-section" id="security">
+    <div class="section-num">08</div>
+    <h2>Security</h2>
+    <p>We take reasonable technical and organisational measures to protect the information we hold against unauthorised access, loss, or misuse. This includes using HTTPS encryption for all data transmitted through this website.</p>
+    <p>However, no method of transmission over the internet is completely secure. While we strive to protect your data, we cannot guarantee absolute security.</p>
+  </section>
+
+  <section class="privacy-section" id="changes">
+    <div class="section-num">09</div>
+    <h2>Changes to This Policy</h2>
+    <p>We may update this Privacy Policy from time to time to reflect changes in our practices or for legal, operational, or regulatory reasons. When we do, we will revise the "Last updated" date at the top of this page.</p>
+    <p>We encourage you to review this page periodically. Continued use of this website after changes are posted constitutes your acceptance of those changes.</p>
+  </section>
+
+  <section class="privacy-section" id="contact">
+    <div class="section-num">10</div>
+    <h2>Contact Us</h2>
+    <p>If you have any questions, concerns, or requests regarding this Privacy Policy or how we handle your data, please contact us through the contact form on this website or at the email address listed on the site.</p>
+    <p>We will make every effort to respond promptly and address your concern.</p>
+  </section>
+</div>
+
+<script>
+  document.getElementById('privacy-date').textContent = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+</script>


### PR DESCRIPTION
## Summary
This PR adds a comprehensive privacy policy page to the website with dedicated styling and layout components.

## Key Changes
- **New privacy policy page** (`privacy-policy/index.html`) with 10 sections covering data collection, usage, cookies, rights, security, and contact information
- **Privacy-specific stylesheet** (`_sass/_privacy.scss`) with custom components:
  - `.privacy-wrap` — Main container with responsive padding and typography
  - `.privacy-toc` — Styled table of contents with custom numbered list styling
  - `.privacy-section` — Individual section styling with numbered headers
  - `.privacy-callout` — Highlighted callout boxes for important information
- **Dynamic date display** — JavaScript automatically updates the "Last updated" date to the current date
- **Stylesheet import** — Added privacy styles to main CSS manifest

## Implementation Details
- Responsive design with mobile breakpoints (480px) for the table of contents
- Uses CSS custom properties for theming (colors, fonts, spacing)
- Semantic HTML structure with proper heading hierarchy and anchor links
- Accessible styling with clear visual hierarchy and readable typography
- Table of contents with auto-numbered list items using CSS counters

https://claude.ai/code/session_01A9aXKC7H6WjsC2tEC8ppJw