### PR TITLE
Add Privacy Policy page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,6 +9,6 @@
       {% if site.github_url %}<a href="{{ site.github_url }}" target="_blank" rel="noopener noreferrer">GitHub</a>{% endif %}
       {% if site.twitter_url %}<a href="{{ site.twitter_url }}" target="_blank" rel="noopener noreferrer">X</a>{% endif %}
     </div>
-    <span class="foot-copy">© {{ site.time | date: '%Y' }} {{ site.title }}</span>
+    <span class="foot-copy">© {{ site.time | date: '%Y' }} {{ site.title }} &nbsp;·&nbsp; <a href="{{ '/privacy-policy/' | relative_url }}">Privacy Policy</a></span>
   </div>
 </footer>

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -39,5 +39,15 @@ footer {
   .foot-copy {
     font-size: 12px;
     color: var(--muted);
+
+    a {
+      color: var(--muted);
+      text-decoration: none;
+      transition: color 0.2s;
+
+      &:hover {
+        color: var(--body);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds a new `/privacy-policy/` page with a 10-section legal document (introduction, data collection, cookies, rights, security, etc.)
- Adds `_sass/_privacy.scss` with page styles adapted to match the site's design system (DM Sans, CSS custom properties)
- Adds a Privacy Policy link in the footer copyright line, with matching muted-color styling

## Test plan

- [ ] Visit `/privacy-policy/` and confirm all 10 sections render correctly with the table of contents
- [ ] Confirm "last updated" date populates dynamically
- [ ] Check footer on any page — Privacy Policy link should appear after the copyright notice
- [ ] Confirm link navigates correctly to `/privacy-policy/`
- [ ] Check mobile layout at ≤480px

https://claude.ai/code/session_01A9aXKC7H6WjsC2tEC8ppJw

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9aXKC7H6WjsC2tEC8ppJw)_